### PR TITLE
修复 cpu_temp.sh 解析BUG

### DIFF
--- a/server/modules/shell_files/cpu_temp.sh
+++ b/server/modules/shell_files/cpu_temp.sh
@@ -3,11 +3,14 @@ if [ `which sensors` ]; then
   returnString=`sensors`
   #amd
   if [[ "${returnString/"k10"}" != "${returnString}" ]] ; then
-    echo ${returnString##*k10} | cut -d ' ' -f 6 | cut -c 2- | cut -c 1-4
+    echo ${returnString##*k10} | cut -d ' ' -f 6 | cut -c 2-5
   #intel
-  elif [[ "${returnString/"core"}" != "${returnString}" ]] ; then
-    fromcore=${returnString##*"coretemp"}
-    echo ${fromcore##*Physical}  | cut -d ' ' -f 3 |  cut -c 2-5
+  elif [[ "${returnString/"coretemp"}" != "${returnString}" ]] ; then
+    fromcore="$(echo "${returnString##*coretemp}" | grep -B1 Core)"
+    # some platform not have 'Physical', don't use `echo ${fromcore##*Physical}`
+    echo ${fromcore#* } | cut -d ' ' -f 3 | cut -c 2-5
+  else
+    echo "[]"
   fi
 else
   echo "[]"


### PR DESCRIPTION
如果sensors没有找到适合的传感器，cpu_temp.sh也应该打印一些内容，否则会导致web端报错(虽然不影响使用)